### PR TITLE
Add check for 'ar' program.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 AC_INIT(Embedded Building Bricks, 0.1, jan.weil@web.de, libmbb)
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_PROG_CC
+AM_PROG_AR
 AC_PROG_RANLIB
 AC_CHECK_PROG(have_ruby, ruby, yes, no)
 if test x$have_ruby != xyes; then


### PR DESCRIPTION
'ar' is required for building the library file. Also we get the
following error without this check.

    /usr/share/automake-1.14/am/library.am: archiver requires
    'AM_PROG_AR' in 'configure.ac'