### PR TITLE
 Minor Fix - Missed out a semicolon

### DIFF
--- a/docs/HSM.md
+++ b/docs/HSM.md
@@ -41,7 +41,7 @@ Example
 	enum {
 		EVENT1 = MHSM_EVENT_CUSTOM,
 		EVENT2
-	}
+	};
 	
 	MHSM_DEFINE_STATE(top, NULL);
 	MHSM_DEFINE_STATE(a, &top);


### PR DESCRIPTION
== Minor ==
Missed out a semicolon in the example code.